### PR TITLE
remove unused GSL includes

### DIFF
--- a/pyprofit.cpp
+++ b/pyprofit.cpp
@@ -32,9 +32,6 @@
 #include <string>
 #include <vector>
 
-#include "gsl/gsl_cdf.h"
-#include "gsl/gsl_sf_gamma.h"
-
 #include "profit/profit.h"
 
 using namespace profit;


### PR DESCRIPTION
GSL isn't used, so no need to `#include` it. The code compiles fine without.